### PR TITLE
fix: Phase 0 — six bugs that bit existing users

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Welcome to **GitSwitch**, the ultimate solution for managing multiple Git users 
 - **SSH Key Management**: Generate and manage SSH keys seamlessly.
 - **SSH Key Upload**: Upload the SSH key.pub to your GitHub/GitLab account directly.
 - **Active User Display**: Easily view the currently active user.
+- **GitHub CLI Sync**: When switching to a GitHub identity, `gh auth switch` runs automatically so `gh pr create`, `gh repo clone`, etc. use the right account.
+- **Non-destructive SSH config**: Updates only the `Host github.com` / `Host gitlab.com` block in `~/.ssh/config`; all your other entries are preserved.
 
 ## 📦 Installation
 GitSwitch can be installed using Homebrew with the following commands:
@@ -34,12 +36,12 @@ brew install target-ops/tap/gitswitch
 GitSwitch provides a command-line interface for managing Git users. Here are the available commands:
 #### Add User
 ```
-gitswitch add user --vendor <vendor> --username <username> --email <email> --pub_key_path <path_to_public_key>
+gitswitch add user --vendor <vendor> --username <username> --email <email> [--generate]
 ```
 
 #### Generate SSH Key
 ```
-gitswitch generate key --email <email> --pub_key_path <path_to_public_key>
+gitswitch generate key --email <email> [--vendor <vendor> --username <username>]
 ```
 #### List Users
 ```

--- a/src/commands/add_command.py
+++ b/src/commands/add_command.py
@@ -54,6 +54,6 @@ def user(vendor, username, email, generate):
     """
     config = load_config()
     if generate:
-        generate_ssh_key(email)
+        generate_ssh_key(email, vendor=vendor, username=username)
     add_user(config, vendor, username, email)
     click.secho(f"User: {username} added for vendor {vendor}.", fg='green')

--- a/src/commands/generate_command.py
+++ b/src/commands/generate_command.py
@@ -15,21 +15,25 @@ def generate():
 
 @click.command(cls=HelpColorsCommand,help_options_color='green')
 @click.option('-e','--email',required=True, help='Email address of the user')
-def key(email):
+@click.option('-v','--vendor', type=click.Choice(["github", "gitlab"]), help='Vendor name (namespaces the key file per vendor)')
+@click.option('-u','--username', help='Username (defaults to the email local-part)')
+def key(email, vendor, username):
     """Generate a new SSH key.
 
-    This command creates a new SSH key pair using the provided email address. 
-    The SSH key is essential for secure communication with Git repositories on platforms like GitHub and GitLab.
+    This command creates a new SSH key pair using the provided email address.
+    The SSH key is essential for secure communication with Git repositories
+    on platforms like GitHub and GitLab.
 
-    The key pair is saved in the ~/.ssh directory.                                                              
-    The private key file is named id_rsa_{username}, where {username} is the part of the email before the '@' symbol.
+    The key pair is saved in the ~/.ssh directory. When --vendor and
+    --username are supplied, the file is named id_rsa_{vendor}_{username};
+    otherwise it falls back to id_rsa_{username} (where {username} is the
+    part of the email before the '@' symbol).
 
     Example usage:\n
-    - gitswitch generate key -e email@example.com
-
-    
+    - gitswitch generate key -e email@example.com\n
+    - gitswitch generate key -v github -u work -e work@company.com
     """
-    generate_ssh_key(email)
+    generate_ssh_key(email, vendor=vendor, username=username)
     click.secho(f"SSH key generated for {email}.", fg='green')
 
 generate.add_command(key)

--- a/src/commands/switch_command.py
+++ b/src/commands/switch_command.py
@@ -4,6 +4,7 @@ from click_help_colors import HelpColorsCommand
 from configs.config import load_config,set_current_user
 from configs.git import set_global_git_user
 from configs.ssh import update_ssh_config
+from configs.gh import switch_gh_user
 
 # @click.command(cls=HelpColorsCommand,help_options_color='green')
 # @click.option('-v','--vendor',required=True,type=click.Choice(["github", "gitlab"]), help='Vendor name')
@@ -45,10 +46,10 @@ def switch(vendor, username):
     config = load_config()
 
     if vendor is None:
-        vendors = list(config.keys())
-        if 'current' in vendors:
-            vendors.remove('DEFAULT')
-            vendors.remove('current')
+        vendors = [v for v in config.keys() if v not in ('DEFAULT', 'current')]
+        if not vendors:
+            click.secho("No users configured yet. Run `gitswitch add user` first.", fg='yellow')
+            return
 
         vendor_questions = [inquirer.List('vendor',message="Select a vendor",choices=vendors)]
         vendor_answers = inquirer.prompt(vendor_questions)
@@ -65,6 +66,8 @@ def switch(vendor, username):
             email, key_path = config[vendor][username].split(',')
             set_global_git_user(username, email)
             update_ssh_config(vendor, key_path)
+            if vendor == 'github':
+                switch_gh_user(username)
             set_current_user(config, vendor, username)
             click.secho("Switched to: " + click.style(username, fg="green"))
         else:

--- a/src/configs/gh.py
+++ b/src/configs/gh.py
@@ -1,0 +1,73 @@
+import shutil
+import subprocess
+import click
+
+
+def is_gh_installed():
+    """Return True if the GitHub CLI (`gh`) is on PATH."""
+    return shutil.which('gh') is not None
+
+
+def gh_logged_in_users():
+    """Return the set of usernames currently authenticated with `gh`."""
+    if not is_gh_installed():
+        return set()
+    result = subprocess.run(
+        ['gh', 'auth', 'status'],
+        capture_output=True, text=True,
+    )
+    # `gh auth status` prints lines like "  - Logged in to github.com account <user>"
+    # on stderr (older versions) or stdout (newer). Parse both.
+    output = (result.stdout or '') + '\n' + (result.stderr or '')
+    users = set()
+    for line in output.splitlines():
+        line = line.strip()
+        if 'account' in line:
+            parts = line.split('account')
+            tail = parts[-1].strip().split()
+            if tail:
+                users.add(tail[0].strip('()'))
+    return users
+
+
+def switch_gh_user(username):
+    """Switch the active `gh` CLI account to `username`.
+
+    Quietly skips if `gh` is not installed. If the user is not yet logged in,
+    surfaces a hint to run `gh auth login`.
+    """
+    if not is_gh_installed():
+        click.secho(
+            "gh CLI not installed; skipping GitHub CLI account switch.",
+            fg='yellow',
+        )
+        return False
+
+    result = subprocess.run(
+        ['gh', 'auth', 'switch', '--user', username],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        click.secho(f"GitHub CLI: switched to {username}.", fg='green')
+        return True
+
+    click.secho(
+        f"GitHub CLI: could not switch to '{username}'. "
+        f"Run `gh auth login` to add this account, then retry.",
+        fg='yellow',
+    )
+    if result.stderr.strip():
+        click.secho(result.stderr.strip(), fg='yellow')
+    return False
+
+
+def login_gh_user():
+    """Run an interactive `gh auth login` so the new account is added to gh."""
+    if not is_gh_installed():
+        click.secho(
+            "gh CLI not installed; skipping `gh auth login`.",
+            fg='yellow',
+        )
+        return False
+    # Use subprocess.call so stdin/stdout stay attached to the user's terminal.
+    return subprocess.call(['gh', 'auth', 'login']) == 0

--- a/src/configs/git.py
+++ b/src/configs/git.py
@@ -4,6 +4,7 @@ import requests
 import re
 from configs.utils import run_command
 from configs.config import save_config
+from configs.ssh import default_key_path
 
 def set_global_git_user(username, email):
     """Function set_global_git_user."""
@@ -12,16 +13,20 @@ def set_global_git_user(username, email):
 
 def add_user(config, vendor, username, email):
     """Function add user."""
-    username = email.split('@')[0]
-    ssh_dir = os.path.expanduser('~/.ssh')
-    key_path = os.path.join(ssh_dir, f'id_rsa_{username}')
-
     if not re.match(r"[^@]+@[^@]+\.[^@]+", email):
         click.secho(f'Invalid email: {email}, expect: example@gmail.com.', fg='red')
         exit(0)
 
+    if not username:
+        username = email.split('@')[0]
+
+    key_path = default_key_path(vendor, username)
     if not os.path.exists(key_path):
-        click.secho(f'SSH key does not exist at: {key_path}, please generate one first by running:\ngitswitch generate key -e example@gmail.com', fg='red')
+        click.secho(
+            f'SSH key does not exist at: {key_path}, please generate one first by running:\n'
+            f'gitswitch generate key -v {vendor} -u {username} -e {email}',
+            fg='red',
+        )
         exit(0)
 
     if vendor not in config:
@@ -67,9 +72,9 @@ def upload_ssh_key_to_vendor(vendor, username, key_path, token):
     }
 
     if vendor == 'github':
-        response = requests.post("https://api.github.com/user/keys", headers=headers, json=data)
+        response = requests.post("https://api.github.com/user/keys", headers=headers, json=data, timeout=10)
     elif vendor == 'gitlab':
-        response = requests.post("https://gitlab.com/api/v4/user/keys", headers=headers, json=data)
+        response = requests.post("https://gitlab.com/api/v4/user/keys", headers=headers, json=data, timeout=10)
     else:
         raise Exception(f"Unsupported vendor: {vendor}")
 

--- a/src/configs/ssh.py
+++ b/src/configs/ssh.py
@@ -6,15 +6,37 @@ from configs.utils import run_command
 
 SSH_CONFIG_FILE = os.path.expanduser('~/.ssh/config')
 
-def generate_ssh_key(email):
+
+def default_key_path(vendor, username):
+    """Resolve the key path for a (vendor, username).
+
+    Prefers the namespaced path id_rsa_{vendor}_{username}. Falls back to the
+    legacy id_rsa_{username} when only that exists, so users who upgraded from
+    earlier versions are not broken.
+    """
+    ssh_dir = os.path.expanduser('~/.ssh')
+    namespaced = os.path.join(ssh_dir, f'id_rsa_{vendor}_{username}') if vendor else None
+    legacy = os.path.join(ssh_dir, f'id_rsa_{username}')
+    if namespaced and os.path.exists(namespaced):
+        return namespaced
+    if os.path.exists(legacy):
+        return legacy
+    return namespaced or legacy
+
+
+def generate_ssh_key(email, vendor=None, username=None):
     """Function generate_ssh_key."""
     if not re.match(r"[^@]+@[^@]+\.[^@]+", email):
         click.secho(f'Invalid email: {email}', fg='red')
         exit(0)
-    
-    username = email.split('@')[0]
+
+    if not username:
+        username = email.split('@')[0]
     ssh_dir = os.path.expanduser('~/.ssh')
-    key_path = os.path.join(ssh_dir, f'id_rsa_{username}')
+    if vendor:
+        key_path = os.path.join(ssh_dir, f'id_rsa_{vendor}_{username}')
+    else:
+        key_path = os.path.join(ssh_dir, f'id_rsa_{username}')
 
     if not os.path.exists(ssh_dir):
         os.makedirs(ssh_dir)
@@ -24,16 +46,54 @@ def generate_ssh_key(email):
         exit(0)
 
     run_command(f'ssh-keygen -b 4096 -t rsa -C "{email}" -f {key_path} -N ""')
+    return key_path
+
+
+def _build_host_block(vendor, key_path):
+    host = f"{vendor}.com"
+    return (
+        f"Host {host}\n"
+        f"    HostName {host}\n"
+        f"    PreferredAuthentications publickey\n"
+        f"    IdentityFile {key_path}\n"
+        f"    IdentitiesOnly yes\n"
+    )
 
 
 def update_ssh_config(vendor, key_path):
-    """Function update_ssh_config."""
-    host_entry = f"""
-Host {vendor}.com
-    HostName {vendor}.com
-    PreferredAuthentications publickey
-    IdentityFile {key_path}
-    """
+    """Replace just the Host block for this vendor; preserve everything else."""
+    host = f"{vendor}.com"
+    new_block = _build_host_block(vendor, key_path)
+
+    ssh_dir = os.path.dirname(SSH_CONFIG_FILE)
+    if not os.path.exists(ssh_dir):
+        os.makedirs(ssh_dir, mode=0o700)
+
+    if not os.path.exists(SSH_CONFIG_FILE):
+        with open(SSH_CONFIG_FILE, 'w') as f:
+            f.write(new_block)
+        os.chmod(SSH_CONFIG_FILE, 0o600)
+        return
+
+    with open(SSH_CONFIG_FILE, 'r') as f:
+        content = f.read()
+
+    # Strip any existing block whose Host line matches this vendor.
+    # A block runs from its `Host` line up to (but not including) the next
+    # top-level `Host` line or end of file.
+    pattern = re.compile(
+        r'^[ \t]*Host[ \t]+[^\n]*\b' + re.escape(host) + r'\b[^\n]*\n'
+        r'(?:(?![ \t]*Host[ \t])[^\n]*\n?)*',
+        re.MULTILINE,
+    )
+    content = pattern.sub('', content)
+
+    if content and not content.endswith('\n'):
+        content += '\n'
+    if content and not content.endswith('\n\n'):
+        content += '\n'
+    content += new_block
 
     with open(SSH_CONFIG_FILE, 'w') as f:
-        f.write(host_entry)
+        f.write(content)
+    os.chmod(SSH_CONFIG_FILE, 0o600)


### PR DESCRIPTION
## Summary

Six bug fixes to stop the bleeding before the planned 1.0 Go rewrite. None change command surface in a breaking way; existing users keep working.

| # | Bug | Fix |
|---|---|---|
| 1 | \`update_ssh_config\` opened \`~/.ssh/config\` with mode \`'w'\`, **wiping every other Host entry** in the file. | Read existing config, surgically replace just the \`Host {vendor}.com\` block, preserve everything else. Adds \`0o600\` perms. Regex tested across mixed entries / fresh file / no-trailing-newline / sibling-vendor cases. |
| 2 | \`add_user\` silently overwrote the user-supplied \`--username\` with \`email.split('@')[0]\`, so \`gitswitch add user -u myname -e foo@bar.com\` stored \`foo\`, not \`myname\`. | Honor the click-supplied username; only fall back to email local-part when none was provided. |
| 3 | Same email local-part across vendors collided to the same key path (\`id_rsa_{user}\`), making the second \`add\` fail. | Namespace per vendor → \`id_rsa_{vendor}_{username}\`. New \`default_key_path()\` helper falls back to legacy \`id_rsa_{username}\` when only that exists, so upgrading users aren't broken. |
| 4 | \`generate key\` only took \`--email\`; couldn't produce a key at the namespaced path consumed by \`add user\`. | Optional \`--vendor\` and \`--username\` flags on \`generate key\`. \`add user --generate\` plumbs both through. |
| 5 | First-time \`gitswitch switch\` without args showed \`DEFAULT\` as a vendor option (configparser's default section bled into the list). | Unconditionally filter \`DEFAULT\` and \`current\` from the picker. Friendly "no users yet" hint when the config is empty. |
| 6 | \`requests.post\` calls in \`upload_ssh_key_to_vendor\` had no timeout — would hang forever on a stalled connection. | \`timeout=10\` on both. |
| 7 | README documented \`--pub_key_path\` on \`add user\`, which doesn't exist on that command. | Removed; documented the new \`generate key\` flags. |

Plus one new module: \`src/configs/gh.py\` wires \`gh auth switch --user <name>\` into the switch flow when \`vendor == github\`, with a helpful hint when the user isn't yet logged in to \`gh\`.

## Verification

13/13 integration checks pass against tempdirs (no real \`~/.ssh\` or \`~/.config\` touched):

\`\`\`
✓ A1 namespaced path
✓ A2 legacy fallback
✓ A3 prefer namespaced over legacy
✓ B1 --username preserved (not overridden by email local-part)
✓ B2 stored entry references namespaced key path
✓ C1 bastion preserved (SSH config)
✓ C2 gitlab preserved (SSH config)
✓ C3 old github key removed
✓ C4 new github key present
✓ D1 picker excludes DEFAULT and current
✓ D2 empty config -> empty list
✓ E1 github timeout
✓ E2 gitlab timeout
\`\`\`

Plus: \`python3 -m py_compile\` clean across all 14 files; CLI \`--help\` and new flags render correctly in venv.

## Test plan

- [ ] \`brew tap target-ops/homebrew-tap && brew install gitswitch\` (after release tag)
- [ ] \`gitswitch generate key -v github -u work -e work@company.com\` → produces \`~/.ssh/id_rsa_github_work\`
- [ ] \`gitswitch add user -v github -u work -e work@company.com\` → stored under \`work\`, not \`work\` from local-part collision
- [ ] \`gitswitch switch\` (no args, fresh config) → no \`DEFAULT\` in picker
- [ ] \`gitswitch switch -v github -u work\` → \`gh auth switch --user work\` runs (or prints friendly hint)
- [ ] \`~/.ssh/config\` retains existing Host entries (bastions, jump hosts, sibling vendor) after switching

## What this PR is **not**

Not the 1.0 rewrite. Not a security tool. Not opinionated about \`includeIf\`. This is a 0.x patch that buys ~30 days of stability while the Go rewrite happens on a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)