### PR TITLE
feat: `gitswitch use` — bind an identity to a directory

### DIFF
--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -1,0 +1,125 @@
+// Package blocks does idempotent edits of plain-text config files
+// (~/.gitconfig, ~/.ssh/config, …) using sentinel comment markers.
+//
+// We mark each gitswitch-managed block with a pair of comments:
+//
+//	# >>> gitswitch:<name>
+//	...
+//	# <<< gitswitch:<name>
+//
+// On every Upsert we strip the previous block (if any) and append the
+// new one, preserving everything else in the file. This lets us
+// re-run `gitswitch use` safely without duplicating includes or
+// growing the file each time.
+package blocks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Marker is the comment sentinel style — typically "#" for
+// gitconfig/sshconfig but extracted so future formats (e.g. ";"-comment
+// configs) can reuse the same machinery.
+type Marker struct {
+	CommentPrefix string // "#" for gitconfig + sshconfig
+	OpenWord      string // "gitswitch:" — concatenated with `name`
+}
+
+// DefaultMarker is the canonical "# >>> gitswitch:<name>" marker.
+var DefaultMarker = Marker{CommentPrefix: "#", OpenWord: "gitswitch:"}
+
+// Upsert reads `path`, removes any existing block named `name`, appends
+// the supplied `body` wrapped in fresh sentinel comments, and writes
+// the result back atomically with `mode` perms. Creates parent dirs
+// and the file itself when missing. The file's other contents are
+// preserved exactly (including non-managed blocks and free-form text).
+func Upsert(path, name, body string, mode os.FileMode) error {
+	return UpsertWithMarker(path, name, body, mode, DefaultMarker)
+}
+
+// UpsertWithMarker is the same as Upsert with a custom comment style.
+func UpsertWithMarker(path, name, body string, mode os.FileMode, m Marker) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	stripped := stripBlock(string(existing), name, m)
+	updated := appendBlock(stripped, name, body, m)
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op if rename succeeded
+
+	if _, err := tmp.WriteString(updated); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// Remove strips the named block from the file (no-op if not present).
+// Useful for an eventual `gitswitch use --unbind`.
+func Remove(path, name string, mode os.FileMode) error {
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	stripped := stripBlock(string(existing), name, DefaultMarker)
+	if stripped == string(existing) {
+		return nil
+	}
+	return os.WriteFile(path, []byte(stripped), mode)
+}
+
+func stripBlock(content, name string, m Marker) string {
+	pattern := blockPattern(name, m)
+	return pattern.ReplaceAllString(content, "")
+}
+
+func appendBlock(content, name, body string, m Marker) string {
+	if content != "" && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	if content != "" && !strings.HasSuffix(content, "\n\n") {
+		content += "\n"
+	}
+	open := fmt.Sprintf("%s >>> %s%s", m.CommentPrefix, m.OpenWord, name)
+	closeLine := fmt.Sprintf("%s <<< %s%s", m.CommentPrefix, m.OpenWord, name)
+	body = strings.TrimRight(body, "\n")
+	return content + open + "\n" + body + "\n" + closeLine + "\n"
+}
+
+// blockPattern matches a full sentinel-wrapped block, including its
+// trailing newline if present. The (?s) flag lets `.` cross newlines.
+func blockPattern(name string, m Marker) *regexp.Regexp {
+	cp := regexp.QuoteMeta(m.CommentPrefix)
+	ow := regexp.QuoteMeta(m.OpenWord + name)
+	return regexp.MustCompile(
+		`(?s)` +
+			`[ \t]*` + cp + `[ \t]*>>>[ \t]*` + ow + `[ \t]*\n` + // open line
+			`.*?` + // body, non-greedy
+			`[ \t]*` + cp + `[ \t]*<<<[ \t]*` + ow + `[ \t]*\n?`, // close line
+	)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -22,5 +22,6 @@ work to a company repo.`,
 
 	root.AddCommand(newDoctorCommand())
 	root.AddCommand(newInitCommand())
+	root.AddCommand(newUseCommand())
 	return root
 }

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/target-ops/gitswitch/internal/blocks"
+	"github.com/target-ops/gitswitch/internal/identity"
+)
+
+func newUseCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "use <identity> [<directory>]",
+		Short: "Bind an identity to a directory.",
+		Long: `Configures git so that any repo inside <directory> automatically
+uses <identity>'s name, email, signing key, and SSH key. Once bound,
+no manual switching is needed — every "cd" into the directory tree
+is the switch.
+
+Concretely, "use" does three things:
+
+  1. Writes ~/.config/gitswitch/identities/<identity>.gitconfig with
+     [user], [commit], [gpg], and [core.sshCommand] sections.
+
+  2. Adds an idempotent includeIf block to ~/.gitconfig that points
+     at the per-identity file when the cwd is inside <directory>.
+
+  3. Records the binding in ~/.config/gitswitch/config.json so
+     "gitswitch why" can explain the link later.
+
+Re-running "use" with the same identity + directory is a no-op (the
+sentinel-marked block is replaced in place). Run with --unbind to
+remove the binding.`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			unbind, _ := cmd.Flags().GetBool("unbind")
+			return runUse(args, unbind)
+		},
+	}
+	cmd.Flags().Bool("unbind", false, "remove the binding instead of creating it")
+	return cmd
+}
+
+func runUse(args []string, unbind bool) error {
+	name := args[0]
+	cfg, err := identity.Load()
+	if err != nil {
+		return err
+	}
+	id := cfg.FindByName(name)
+	if id == nil {
+		return fmt.Errorf("no identity named %q. Run `gitswitch list` to see what's configured, or `gitswitch init` to detect identities", name)
+	}
+
+	// 1. Always (re)write the per-identity gitconfig — easier to keep
+	// it consistent with the stored Identity than to diff.
+	if err := identity.WriteGitconfig(*id); err != nil {
+		return fmt.Errorf("write per-identity gitconfig: %w", err)
+	}
+
+	if len(args) == 1 {
+		// Just refresh the per-identity file, no directory binding.
+		fmt.Printf("%s✓%s refreshed %s\n",
+			green, reset, identity.GitconfigPath(name))
+		fmt.Printf("%s  (no directory specified — pass <directory> to bind)%s\n", dim, reset)
+		return nil
+	}
+
+	dir, err := resolveDir(args[1])
+	if err != nil {
+		return err
+	}
+
+	if unbind {
+		if err := removeBinding(cfg, name, dir); err != nil {
+			return err
+		}
+		if err := identity.Save(cfg); err != nil {
+			return err
+		}
+		fmt.Printf("%s✓%s unbound %s from %s\n", green, reset, name, dir)
+		return nil
+	}
+
+	// 2. Update ~/.gitconfig with an idempotent includeIf block.
+	gitconfigPath := filepath.Join(os.Getenv("HOME"), ".gitconfig")
+	blockBody := buildIncludeIfBlock(dir, identity.GitconfigPath(name))
+	if err := blocks.Upsert(gitconfigPath, name, blockBody, 0o600); err != nil {
+		return fmt.Errorf("update ~/.gitconfig: %w", err)
+	}
+
+	// 3. Record the binding.
+	addBinding(cfg, name, dir)
+	if err := identity.Save(cfg); err != nil {
+		return err
+	}
+
+	fmt.Printf("%s%s✓ bound %s%s%s%s → %s%s%s\n",
+		green, bold, reset, bold, name, reset, dim, dir, reset)
+	fmt.Println()
+	fmt.Printf("  %sper-identity config:%s %s\n", dim, reset, identity.GitconfigPath(name))
+	fmt.Printf("  %sincludeIf in:%s        %s\n", dim, reset, gitconfigPath)
+	fmt.Println()
+	fmt.Printf("%scd into %s and your git identity becomes %s automatically.%s\n",
+		dim, dir, name, reset)
+	fmt.Println()
+	fmt.Printf("Verify it worked:  %scd %s && gitswitch doctor%s\n", dim, dir, reset)
+	return nil
+}
+
+// buildIncludeIfBlock renders the body of the sentinel-wrapped block
+// we drop into ~/.gitconfig. Trailing slash on gitdir is mandatory —
+// without it the pattern matches the literal directory name only and
+// nothing inside it. This is the single most common gotcha in every
+// "managing multiple Git identities" tutorial.
+func buildIncludeIfBlock(dir, includePath string) string {
+	dir = strings.TrimRight(dir, "/") + "/"
+	return fmt.Sprintf("[includeIf \"gitdir:%s\"]\n    path = %s\n",
+		dir, includePath)
+}
+
+// resolveDir expands ~/ and ./, validates the directory exists, and
+// returns an absolute path. Pre-flight check so users don't bind to a
+// path with a typo and only discover the breakage at commit time.
+func resolveDir(in string) (string, error) {
+	if strings.HasPrefix(in, "~/") {
+		in = filepath.Join(os.Getenv("HOME"), in[2:])
+	}
+	abs, err := filepath.Abs(in)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("directory does not exist: %s", abs)
+		}
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("not a directory: %s", abs)
+	}
+	return abs, nil
+}
+
+func addBinding(c *identity.Config, name, dir string) {
+	for i, b := range c.Bindings {
+		if b.Directory == dir {
+			c.Bindings[i].Identity = name
+			return
+		}
+	}
+	c.Bindings = append(c.Bindings, identity.Binding{Directory: dir, Identity: name})
+}
+
+func removeBinding(c *identity.Config, name, dir string) error {
+	for i, b := range c.Bindings {
+		if b.Directory == dir && b.Identity == name {
+			c.Bindings = append(c.Bindings[:i], c.Bindings[i+1:]...)
+			gitconfigPath := filepath.Join(os.Getenv("HOME"), ".gitconfig")
+			return blocks.Remove(gitconfigPath, name, 0o600)
+		}
+	}
+	return fmt.Errorf("%s is not bound to %s", name, dir)
+}

--- a/internal/identity/files.go
+++ b/internal/identity/files.go
@@ -1,0 +1,69 @@
+package identity
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// IdentitiesDir returns the directory where per-identity gitconfig
+// files live. Mirrors the layout decision in Path() — honours
+// $XDG_CONFIG_HOME.
+func IdentitiesDir() string {
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "gitswitch", "identities")
+	}
+	return filepath.Join(os.Getenv("HOME"), ".config", "gitswitch", "identities")
+}
+
+// GitconfigPath returns the path of the per-identity gitconfig file
+// for `name`.
+func GitconfigPath(name string) string {
+	return filepath.Join(IdentitiesDir(), name+".gitconfig")
+}
+
+// WriteGitconfig writes the per-identity gitconfig for the given
+// identity. The file is included by ~/.gitconfig via includeIf when
+// the user is inside the bound directory. SSH commit signing is
+// enabled by default when SigningKey is set; .core.sshCommand is set
+// only when SSHKey is non-empty (so users without a key still get a
+// usable identity).
+func WriteGitconfig(id Identity) error {
+	if err := os.MkdirAll(IdentitiesDir(), 0o700); err != nil {
+		return err
+	}
+	path := GitconfigPath(id.Name)
+
+	var sb strings.Builder
+	sb.WriteString("# gitswitch-managed file. Do not edit by hand.\n")
+	sb.WriteString("# Regenerated whenever `gitswitch use " + id.Name + "` runs.\n\n")
+
+	sb.WriteString("[user]\n")
+	if id.GitName != "" {
+		fmt.Fprintf(&sb, "    name = %s\n", id.GitName)
+	}
+	if id.Email != "" {
+		fmt.Fprintf(&sb, "    email = %s\n", id.Email)
+	}
+	if id.SigningKey != "" {
+		fmt.Fprintf(&sb, "    signingkey = %s\n", id.SigningKey)
+	}
+
+	if id.SigningKey != "" {
+		sb.WriteString("\n[commit]\n    gpgsign = true\n")
+		sb.WriteString("\n[tag]\n    gpgsign = true\n")
+		sb.WriteString("\n[gpg]\n    format = ssh\n")
+	}
+
+	if id.SSHKey != "" {
+		sb.WriteString("\n[core]\n")
+		// Important: IdentitiesOnly=yes prevents ssh-agent from offering
+		// every other key in the keychain to GitHub, which is both a
+		// privacy leak and the source of the famous "Permission denied
+		// (publickey)" failure when you have multiple accounts.
+		fmt.Fprintf(&sb, "    sshCommand = ssh -i %s -o IdentitiesOnly=yes\n", id.SSHKey)
+	}
+
+	return os.WriteFile(path, []byte(sb.String()), 0o600)
+}


### PR DESCRIPTION
Third Phase 1 slice. **After this, the v1.0 promise actually works on disk:** *cd into a directory and your git identity is correct, automatically.*

## The user-facing experience

\`\`\`
$ gitswitch use ofirhaim1 ~/work
✓ bound ofirhaim1 → /Users/ofirhaim/work

  per-identity config: ~/.config/gitswitch/identities/ofirhaim1.gitconfig
  includeIf in:        ~/.gitconfig

cd into /Users/ofirhaim/work and your git identity becomes ofirhaim1 automatically.

Verify it worked:  cd /Users/ofirhaim/work && gitswitch doctor
\`\`\`

\`gitswitch use\` does three things, atomically:

1. **Writes \`~/.config/gitswitch/identities/<id>.gitconfig\`** with \`[user]\`, \`[commit]\`/\`[tag]\` gpgsign=true, \`[gpg]\` format=ssh, and \`[core] sshCommand = ssh -i <key> -o IdentitiesOnly=yes\`. SSH commit signing on by default — verified badges come free.
2. **Adds an \`includeIf\` block to \`~/.gitconfig\`** wrapped in sentinel comments (\`# >>> gitswitch:<name>\` / \`# <<< gitswitch:<name>\`) so re-running is idempotent.
3. **Records the binding in \`~/.config/gitswitch/config.json\`** so future commands (\`why\`, \`doctor\`, \`guard\`) can explain the link.

## Why \`core.sshCommand\` instead of per-account SSH host aliases

The textbook way to do "different key per directory" is to write a \`Host github.com-work\` alias into \`~/.ssh/config\` and rewrite all your repo remotes to \`git@github.com-work:…\`. That works but:
- We'd edit the user's SSH config (invasive).
- URL rewriting affects every existing clone.
- Setup gets fragile when multiple tools (1Password SSH, ssh-agent, custom configs) are involved.

\`core.sshCommand\` reaches the same outcome by setting the SSH invocation per-include. Git uses the right key, no \`~/.ssh/config\` mutation, no remote-URL rewriting needed. Simpler, safer first cut.

The host-alias path remains the only way to handle multi-account-on-the-same-vendor (where you really do need different SSH host strings to disambiguate). That'll come in a later PR when we tackle two-GitHub-accounts.

## What's in the PR

| Path | Purpose | Lines |
|---|---|---|
| \`internal/blocks/blocks.go\` | Sentinel-marked block read/replace/append. Atomic write. Reusable for future SSH/shell-rc edits. | ~110 |
| \`internal/identity/files.go\` | \`WriteGitconfig()\` emits the per-identity \`*.gitconfig\` | ~70 |
| \`internal/cmd/use.go\` | The command. Path resolution, idempotent block management, binding upsert, friendly error messages, \`--unbind\` | ~170 |
| \`internal/cmd/root.go\` | Register \`use\` | trivial |

## Verified end-to-end against an isolated \$HOME

- ✓ Bind succeeds, output is human-readable, paths are correct.
- ✓ Per-identity gitconfig contains all expected sections (user, commit, tag, gpg, core).
- ✓ \`~/.gitconfig\` retains pre-existing entries (\`[core] editor = nvim\`, \`[init] defaultBranch = main\`) — only adds the sentinel-wrapped block.
- ✓ Re-running \`use\` with same args is idempotent — exactly one block in the file.
- ✓ Unknown identity errors cleanly with a helpful "run \`gitswitch list\` or \`gitswitch init\`" hint.
- ✓ Non-existent directory errors before any files are touched.
- ✓ \`--unbind\` strips the block, preserves all other content, removes the binding from JSON.

## Test plan after merge

- [ ] On a real machine: \`gitswitch use ofirhaim1 ~/work\`, then \`cd ~/work && git config user.email\` returns the bound email.
- [ ] Inside \`~/work\`, \`git commit\` produces a commit authored by the bound identity.
- [ ] Inside \`~/work\`, \`gitswitch doctor\` agrees end-to-end (the next slice — \`why\` — will surface the includeIf chain).
- [ ] \`gitswitch use ofirhaim1 ~/work --unbind\` followed by \`cd ~/work && git config user.email\` returns the global default again (binding fully reversed).

## What's next

- **PR #12 — \`gitswitch guard install\`** (the pre-commit hook; the killer feature).
- PR #13 — v0.2.x \`~/.config.ini\` migration so existing brew users upgrade cleanly.
- PR #14 — GoReleaser cross-compile + GitHub Actions release workflow.
- PR #15 — Brew formula switch to prebuilt binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)