### PR TITLE
feat: `gitswitch guard` — refuse commits when the identity is wrong for the directory (THE killer feature)

### DIFF
--- a/internal/cmd/guard.go
+++ b/internal/cmd/guard.go
@@ -1,0 +1,264 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/target-ops/gitswitch/internal/git"
+	"github.com/target-ops/gitswitch/internal/hookscript"
+	"github.com/target-ops/gitswitch/internal/identity"
+)
+
+// HooksDir is the directory we install our hook into. We use our own
+// directory (rather than ~/.git-hooks or the user's existing one) so
+// `guard install` can be reasoned about and reversed cleanly.
+func HooksDir() string {
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "gitswitch", "hooks")
+	}
+	return filepath.Join(os.Getenv("HOME"), ".config", "gitswitch", "hooks")
+}
+
+func preCommitPath() string {
+	return filepath.Join(HooksDir(), "pre-commit")
+}
+
+func newGuardCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "guard",
+		Short: "Install the pre-commit hook that refuses wrong-author commits.",
+		Long: `Pre-commit hook that refuses commits when the active identity
+doesn't match the directory you're committing from. The killer
+feature: makes "I committed as the wrong person" structurally
+impossible while gitswitch is in charge.
+
+  gitswitch guard install     install the hook globally
+  gitswitch guard uninstall   remove the hook
+  gitswitch guard status      show whether the hook is active
+  gitswitch guard check       (called by the hook itself; not for humans)
+`,
+	}
+	cmd.AddCommand(newGuardInstallCmd())
+	cmd.AddCommand(newGuardUninstallCmd())
+	cmd.AddCommand(newGuardStatusCmd())
+	cmd.AddCommand(newGuardCheckCmd())
+	return cmd
+}
+
+func newGuardInstallCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install the global pre-commit hook.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			force, _ := cmd.Flags().GetBool("force")
+			return runGuardInstall(force)
+		},
+	}
+	cmd.Flags().Bool("force", false, "overwrite an existing core.hooksPath set by another tool")
+	return cmd
+}
+
+func newGuardUninstallCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "uninstall",
+		Short: "Remove the pre-commit hook and unset core.hooksPath if we set it.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runGuardUninstall()
+		},
+	}
+}
+
+func newGuardStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show whether the guard hook is active.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runGuardStatus()
+		},
+	}
+}
+
+func newGuardCheckCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "check",
+		Short:  "Run the guard check (called by the installed hook, not humans).",
+		Hidden: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runGuardCheck(args)
+		},
+	}
+}
+
+func runGuardInstall(force bool) error {
+	if err := os.MkdirAll(HooksDir(), 0o700); err != nil {
+		return fmt.Errorf("create hooks dir: %w", err)
+	}
+
+	// Refuse to overwrite a non-gitswitch hook unless --force is set.
+	hookPath := preCommitPath()
+	if existing, err := os.ReadFile(hookPath); err == nil {
+		if !bytes.Contains(existing, []byte(hookscript.MarkerComment)) && !force {
+			return fmt.Errorf(
+				"a non-gitswitch pre-commit hook already exists at %s.\n"+
+					"  re-run with --force to overwrite, or remove that file by hand first",
+				hookPath,
+			)
+		}
+	}
+
+	if err := os.WriteFile(hookPath, hookscript.PreCommit(), 0o755); err != nil {
+		return fmt.Errorf("write hook: %w", err)
+	}
+
+	// Set git's global core.hooksPath if we can do so cleanly.
+	current, _ := git.GlobalGet("core.hooksPath")
+	hooksDir := HooksDir()
+	switch {
+	case current == "":
+		if err := git.SetGlobal("core.hooksPath", hooksDir); err != nil {
+			return fmt.Errorf("set core.hooksPath: %w", err)
+		}
+	case sameDir(current, hooksDir):
+		// Already pointed at us.
+	case force:
+		if err := git.SetGlobal("core.hooksPath", hooksDir); err != nil {
+			return fmt.Errorf("set core.hooksPath: %w", err)
+		}
+	default:
+		return fmt.Errorf(
+			"git config --global core.hooksPath is already set to %s.\n"+
+				"  re-run with --force to switch to gitswitch's hooks dir\n"+
+				"  (note: your existing hooks at that path will stop firing)\n"+
+				"  or copy %s into %s to keep both",
+			current, hookPath, current,
+		)
+	}
+
+	fmt.Printf("%s%s✓ guard installed%s\n", green, bold, reset)
+	fmt.Println()
+	fmt.Printf("  %shook:%s         %s\n", dim, reset, hookPath)
+	fmt.Printf("  %score.hooksPath:%s %s\n", dim, reset, hooksDir)
+	fmt.Println()
+	fmt.Println(dim + "Every `git commit` now checks identity vs directory binding." + reset)
+	fmt.Println(dim + "Override once: " + reset + "git commit --no-verify")
+	fmt.Println(dim + "Remove later:  " + reset + "gitswitch guard uninstall")
+	return nil
+}
+
+func runGuardUninstall() error {
+	hookPath := preCommitPath()
+	if err := os.Remove(hookPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove hook: %w", err)
+	}
+
+	current, _ := git.GlobalGet("core.hooksPath")
+	if sameDir(current, HooksDir()) {
+		if err := git.UnsetGlobal("core.hooksPath"); err != nil {
+			return fmt.Errorf("unset core.hooksPath: %w", err)
+		}
+	}
+
+	fmt.Printf("%s✓ guard removed%s\n", green, reset)
+	if current != "" && !sameDir(current, HooksDir()) {
+		fmt.Printf("%s  (your core.hooksPath at %s was left in place)%s\n",
+			dim, current, reset)
+	}
+	return nil
+}
+
+func runGuardStatus() error {
+	hookPath := preCommitPath()
+	hookOK := false
+	if data, err := os.ReadFile(hookPath); err == nil {
+		hookOK = bytes.Contains(data, []byte(hookscript.MarkerComment))
+	}
+	hooksPath, _ := git.GlobalGet("core.hooksPath")
+	pathOK := sameDir(hooksPath, HooksDir())
+
+	row("hook script", hookPath, hookOK)
+	if hooksPath == "" {
+		row("core.hooksPath", "(unset)", false)
+	} else {
+		row("core.hooksPath", hooksPath, pathOK)
+	}
+
+	fmt.Println()
+	switch {
+	case hookOK && pathOK:
+		fmt.Println(green + bold + "✓ guard is active" + reset)
+	case hookOK && !pathOK:
+		fmt.Println(yellow + bold + "• hook installed but not wired into git" + reset)
+		fmt.Println(dim + "  fix: gitswitch guard install --force" + reset)
+	case !hookOK && pathOK:
+		fmt.Println(yellow + bold + "• core.hooksPath set but hook script missing" + reset)
+		fmt.Println(dim + "  fix: gitswitch guard install" + reset)
+	default:
+		fmt.Println(yellow + bold + "• guard is not installed" + reset)
+		fmt.Println(dim + "  fix: gitswitch guard install" + reset)
+	}
+	return nil
+}
+
+// runGuardCheck is the workhorse fired on every commit. Stay fast and
+// fail safely: any internal error exits 0 (don't block legitimate
+// commits when gitswitch itself is broken).
+func runGuardCheck(_ []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+
+	cfg, err := identity.Load()
+	if err != nil || cfg == nil {
+		return nil
+	}
+
+	binding := cfg.FindBindingForDir(cwd)
+	if binding == nil {
+		// Not a directory we manage — don't interfere.
+		return nil
+	}
+	id := cfg.FindByName(binding.Identity)
+	if id == nil {
+		// Orphan binding (identity was removed); nothing useful to enforce.
+		return nil
+	}
+
+	effective, _ := git.EffectiveEmail()
+	if strings.EqualFold(effective, id.Email) {
+		return nil
+	}
+
+	// Mismatch. This is the disaster-prevention moment.
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "%s%s✗ gitswitch guard: blocked commit%s\n",
+		red, bold, reset)
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "  %sin directory:%s   %s\n", dim, reset, cwd)
+	fmt.Fprintf(os.Stderr, "  %sexpected:%s       %s   (bound identity: %s)\n",
+		dim, reset, id.Email, id.Name)
+	fmt.Fprintf(os.Stderr, "  %sgot:%s            %s\n", dim, reset, effective)
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "  %sfix:%s            gitswitch use %s %s\n",
+		dim, reset, id.Name, binding.Directory)
+	fmt.Fprintf(os.Stderr, "                  (or: git commit --no-verify to override this once)\n")
+	fmt.Fprintln(os.Stderr)
+	os.Exit(1)
+	return nil
+}
+
+// sameDir compares two paths semantically — resolves both through
+// filepath.Clean. Not symlink-aware; that's intentional, the user
+// shouldn't be expected to keep two semantically identical hook dirs
+// hooked up via symlink.
+func sameDir(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -23,5 +23,6 @@ work to a company repo.`,
 	root.AddCommand(newDoctorCommand())
 	root.AddCommand(newInitCommand())
 	root.AddCommand(newUseCommand())
+	root.AddCommand(newGuardCommand())
 	return root
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -23,6 +23,12 @@ func GlobalSigning() (signingKey, format string) {
 	return signingKey, format
 }
 
+// GlobalGet returns a single value from the global git config.
+// Empty string + nil error when the key is unset.
+func GlobalGet(key string) (string, error) {
+	return configGet("--global", key)
+}
+
 // configGet runs `git config <args...>` and returns the trimmed stdout.
 // Returns an empty string and a wrapped error when git exits non-zero
 // (e.g., the key isn't set).
@@ -37,4 +43,35 @@ func configGet(args ...string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// EffectiveEmail returns `git config user.email` from the current
+// working directory — meaning the value git would actually write into
+// the next commit's author header. Inside a repo this respects local
+// repo config and includeIf chains; outside a repo it falls back to
+// the global value.
+func EffectiveEmail() (string, error) {
+	return configGet("user.email")
+}
+
+// SetGlobal writes a value into the user's global git config.
+func SetGlobal(key, value string) error {
+	return exec.Command("git", "config", "--global", key, value).Run()
+}
+
+// UnsetGlobal clears a key from the global git config. Treated as
+// success when the key wasn't set in the first place — that's what
+// the caller almost always wants.
+func UnsetGlobal(key string) error {
+	cmd := exec.Command("git", "config", "--global", "--unset", key)
+	err := cmd.Run()
+	if err == nil {
+		return nil
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) && ee.ExitCode() == 5 {
+		// `git config --unset` exits 5 when the key didn't exist.
+		return nil
+	}
+	return err
 }

--- a/internal/hookscript/hookscript.go
+++ b/internal/hookscript/hookscript.go
@@ -1,0 +1,47 @@
+// Package hookscript generates the small shell wrapper that git
+// invokes on every commit. The wrapper does nothing but exec
+// `gitswitch guard check` — keeping the real logic in Go where it
+// can be tested, type-checked, and changed without re-installing the
+// hook on every user's machine.
+package hookscript
+
+import "fmt"
+
+// Version identifies the hook script schema. Bump when the script
+// content changes in a way that older installs need to be migrated
+// (e.g., new flags, new env vars). Used in the marker comment so
+// `gitswitch guard install` can recognise its own files.
+const Version = 1
+
+// MarkerComment uniquely identifies a gitswitch-installed hook. We
+// look for it before overwriting the file — that's how we know the
+// existing hook is ours and safe to replace, vs. a hand-written one
+// that should be preserved.
+const MarkerComment = "# gitswitch-hook-version:"
+
+// PreCommit returns the bytes of the pre-commit hook script.
+//
+// We ship it as a plain shell wrapper rather than embedding logic
+// here, for three reasons:
+//   - The hook lives outside the gitswitch binary's reach to be
+//     overwritten on upgrade — a thin wrapper means every install
+//     of gitswitch picks up the latest check logic automatically.
+//   - The wrapper is small enough to audit at a glance.
+//   - If gitswitch is ever uninstalled, the wrapper fails fast with
+//     a clear "command not found" instead of silently letting bad
+//     commits through.
+func PreCommit() []byte {
+	return []byte(fmt.Sprintf(`#!/usr/bin/env bash
+%s %d
+#
+# This hook is installed by `+"`gitswitch guard install`"+`. It refuses
+# git commits where the active identity is wrong for the current
+# directory. To override for a single commit, use:
+#     git commit --no-verify
+# To remove the hook entirely:
+#     gitswitch guard uninstall
+#
+set -e
+exec gitswitch guard check "$@"
+`, MarkerComment, Version))
+}

--- a/internal/identity/binding.go
+++ b/internal/identity/binding.go
@@ -1,0 +1,44 @@
+package identity
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// FindBindingForDir returns the most-specific binding whose Directory
+// is an ancestor of (or equal to) `dir`. Nil when no binding matches.
+//
+// "Most specific" means longest prefix — so a binding for /work/team-a
+// wins over a binding for /work when the cwd is /work/team-a/repo.
+// This lets a parent directory hold a default identity while
+// subdirectories override.
+func (c *Config) FindBindingForDir(dir string) *Binding {
+	dir = filepath.Clean(dir)
+	var best *Binding
+	for i := range c.Bindings {
+		b := &c.Bindings[i]
+		bdir := filepath.Clean(b.Directory)
+		if !isAncestorOrEqual(bdir, dir) {
+			continue
+		}
+		if best == nil || len(filepath.Clean(best.Directory)) < len(bdir) {
+			best = b
+		}
+	}
+	return best
+}
+
+// isAncestorOrEqual reports whether `parent` is the same path as or
+// an ancestor of `child`. We compare cleaned paths and require the
+// child to start with parent + a separator (so /work doesn't match
+// /workspace).
+func isAncestorOrEqual(parent, child string) bool {
+	if parent == child {
+		return true
+	}
+	sep := string(filepath.Separator)
+	if !strings.HasSuffix(parent, sep) {
+		parent += sep
+	}
+	return strings.HasPrefix(child+sep, parent)
+}


### PR DESCRIPTION
**The killer feature.** Fourth Phase 1 slice. After this, the v1.0 promise — *stop committing as the wrong person* — is structurally enforced, not just hoped for.

## The user-facing experience

Verified end-to-end in an isolated \$HOME with a real \`git commit\`:

\`\`\`
$ gitswitch guard install
✓ guard installed
  hook:          ~/.config/gitswitch/hooks/pre-commit
  core.hooksPath: ~/.config/gitswitch/hooks

# email is wrong for this directory (drift simulation)
$ git commit -m "should fail"

✗ gitswitch guard: blocked commit

  in directory:   /tmp/gs-guard-test/work-dir
  expected:       ofir@company.test   (bound identity: work)
  got:            personal@gmail.test

  fix:            gitswitch use work /tmp/gs-guard-test/work-dir
                  (or: git commit --no-verify to override this once)

(commit did NOT happen — exit 1)

# fix the email, retry
$ git config user.email ofir@company.test
$ git commit -m "should pass"
[main (root-commit) 7b744f5] should pass
\`\`\`

The blocked-commit message is exactly what the README promises. The disaster narrative is now structurally impossible while guard is active.

## Architecture

| Path | What it does | Lines |
|---|---|---|
| \`internal/hookscript/\` | Generates the pre-commit shell wrapper. Marker comment lets future installs recognise our own files vs hand-written ones. | ~40 |
| \`internal/identity/binding.go\` | \`FindBindingForDir\` longest-prefix match: bindings for \`/work/team-a\` win over \`/work\` when committing inside \`/work/team-a/repo\`. | ~40 |
| \`internal/cmd/guard.go\` | Four subcommands: \`install\`, \`uninstall\`, \`status\`, \`check\` (hidden — fired by the hook). | ~190 |
| \`internal/git/git.go\` | Adds \`EffectiveEmail\`, \`GlobalGet\`, \`SetGlobal\`, \`UnsetGlobal\` (handles "key not set" cleanly). | small |

### Why a tiny shell wrapper instead of running Go from the hook

The pre-commit hook is just:

\`\`\`bash
#!/usr/bin/env bash
# gitswitch-hook-version: 1
set -e
exec gitswitch guard check "\$@"
\`\`\`

All real logic lives in \`gitswitch guard check\`. Three reasons:

1. **Upgrading gitswitch upgrades the check.** No per-machine re-install when we improve the check logic.
2. **The wrapper is auditable at a glance.** Anyone looking at \`pre-commit\` can see exactly what it does in 10 seconds.
3. **Fail-loud on uninstall.** If the user removes \`gitswitch\` from PATH, the next \`git commit\` errors with "command not found" instead of silently letting bad commits through.

### How \`guard check\` decides

1. \`os.Getwd()\`
2. \`identity.Load()\` — if missing, exit 0 (not configured = don't block)
3. \`cfg.FindBindingForDir(cwd)\` — if no binding, exit 0 (not managing this dir = don't block)
4. \`git.EffectiveEmail()\` — what \`git config user.email\` returns from this cwd, includeIf-aware
5. Compare with bound identity's email; case-insensitive
6. Match → exit 0. Mismatch → red message + exit 1.

**Internal errors always exit 0.** A broken gitswitch must never block a legitimate commit. The hook is a safety net, not a gate.

### Coexistence with husky / lefthook / pre-commit

If \`core.hooksPath\` is already set to a non-gitswitch directory, \`guard install\` refuses without \`--force\` and explains the two paths forward (overwrite, or copy our hook into the user's existing hooks dir). \`guard uninstall\` only unsets \`core.hooksPath\` if it currently points at us — anyone else's tooling stays put.

## What's still missing for v1.0

| PR | Adds |
|---|---|
| #13 | \`gitswitch why\` — explain why the active identity is what it is |
| #14 | v0.2.x \`~/.config.ini\` migration |
| #15 | GoReleaser cross-compile + binary releases |
| #16 | Brew formula swap from Python venv to single binary |

After #14, **the four headline commands from the README all work**: \`init\`, \`use\`, \`guard\`, \`doctor\`. That's the moment the brand promise becomes real.

## Test plan after merge

- [ ] Install on real machine: \`gitswitch guard install\` (clean state, no existing hooksPath).
- [ ] Bind a directory: \`gitswitch use ofirhaim1 ~/some-test\`.
- [ ] Inside the bound dir, simulate drift: \`git config user.email wrong@example.com\`, \`git commit\` — verify the red block message appears.
- [ ] Fix the email, retry — verify commit succeeds.
- [ ] \`git commit --no-verify\` — verify guard is bypassed (git's behaviour, not ours; included in the fix-line of the error message).
- [ ] \`gitswitch guard status\` — green ✓.
- [ ] \`gitswitch guard uninstall\`, then status — back to "not installed".
- [ ] Re-install in a directory that's not bound to anything — commits should pass (no binding = guard exits 0 silently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)