### PR TITLE
feat: centralised CLI styling — colour, --no-color, NO_COLOR, bordered panels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.26.2
 
 require (
 	github.com/charmbracelet/huh v1.0.0
+	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/mattn/go-isatty v0.0.22
 	github.com/spf13/cobra v1.10.2
 )
 
@@ -14,7 +16,6 @@ require (
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
 	github.com/charmbracelet/bubbletea v1.3.6 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
@@ -23,7 +24,6 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
+github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
@@ -77,7 +77,6 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQz
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
 golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=

--- a/internal/cmd/colors.go
+++ b/internal/cmd/colors.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"github.com/target-ops/gitswitch/internal/style"
+)
+
+// Color prefixes / reset suffix used inline in command output.
+//
+// These are package-level vars (not consts) so the cobra root command
+// can flip them off at runtime when --no-color is set, and so we
+// honour the auto-detected NO_COLOR / non-TTY state from the style
+// package on first import.
+//
+// Why we keep prefix-style strings instead of going full lipgloss:
+// the cmd/ files concatenate these into f-strings and printf calls
+// dozens of times. Migrating all 80+ sites to lipgloss.Render() at
+// once would balloon the diff and risk subtle output regressions.
+// Letting the prefix/suffix shape stay while routing through `style`
+// gets us NO_COLOR support and per-flag override with one small file
+// instead of a sweeping rewrite.
+var (
+	green  string
+	yellow string
+	red    string
+	blue   string
+	dim    string
+	bold   string
+	reset  string
+)
+
+func init() { applyColorState() }
+
+// disableColors zeros all color variables — used when --no-color or
+// NO_COLOR or non-TTY stdout is detected.
+func disableColors() {
+	green, yellow, red, blue, dim, bold, reset = "", "", "", "", "", "", ""
+}
+
+// enableColors sets the standard ANSI prefixes/suffix.
+func enableColors() {
+	green = "\033[32m"
+	yellow = "\033[33m"
+	red = "\033[31m"
+	blue = "\033[34m"
+	dim = "\033[2m"
+	bold = "\033[1m"
+	reset = "\033[0m"
+}
+
+// applyColorState reads the current style.IsEnabled() and updates
+// the prefix vars accordingly. Called once at init; called again by
+// root.go after parsing --no-color so the flag wins over auto-detect.
+func applyColorState() {
+	if style.IsEnabled() {
+		enableColors()
+	} else {
+		disableColors()
+	}
+}

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -12,16 +12,6 @@ import (
 	"github.com/target-ops/gitswitch/internal/ssh"
 )
 
-// ANSI for terminals — we'll swap in a real color lib in a later PR.
-const (
-	green  = "\033[32m"
-	yellow = "\033[33m"
-	red    = "\033[31m"
-	dim    = "\033[2m"
-	bold   = "\033[1m"
-	reset  = "\033[0m"
-)
-
 func newDoctorCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "doctor",

--- a/internal/cmd/guard.go
+++ b/internal/cmd/guard.go
@@ -12,6 +12,7 @@ import (
 	"github.com/target-ops/gitswitch/internal/git"
 	"github.com/target-ops/gitswitch/internal/hookscript"
 	"github.com/target-ops/gitswitch/internal/identity"
+	"github.com/target-ops/gitswitch/internal/style"
 )
 
 // HooksDir is the directory we install our hook into. We use our own
@@ -139,10 +140,15 @@ func runGuardInstall(force bool) error {
 		)
 	}
 
-	fmt.Printf("%s%s✓ guard installed%s\n", green, bold, reset)
-	fmt.Println()
-	fmt.Printf("  %shook:%s         %s\n", dim, reset, hookPath)
-	fmt.Printf("  %score.hooksPath:%s %s\n", dim, reset, hooksDir)
+	body := fmt.Sprintf(
+		"%s%s✓ guard installed%s\n\n"+
+			"  %shook:%s           %s\n"+
+			"  %score.hooksPath:%s %s",
+		green, bold, reset,
+		dim, reset, hookPath,
+		dim, reset, hooksDir,
+	)
+	fmt.Println(style.Box(body, style.BoxSuccess))
 	fmt.Println()
 	fmt.Println(dim + "Every `git commit` now checks identity vs directory binding." + reset)
 	fmt.Println(dim + "Override once: " + reset + "git commit --no-verify")
@@ -235,18 +241,21 @@ func runGuardCheck(_ []string) error {
 	}
 
 	// Mismatch. This is the disaster-prevention moment.
+	body := fmt.Sprintf(
+		"%s%s✗ gitswitch guard: blocked commit%s\n\n"+
+			"  %sin directory:%s   %s\n"+
+			"  %sexpected:%s       %s   (bound identity: %s)\n"+
+			"  %sgot:%s            %s\n\n"+
+			"  %sfix:%s            gitswitch use %s %s\n"+
+			"                  (or: git commit --no-verify to override this once)",
+		red, bold, reset,
+		dim, reset, cwd,
+		dim, reset, id.Email, id.Name,
+		dim, reset, effective,
+		dim, reset, id.Name, binding.Directory,
+	)
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintf(os.Stderr, "%s%s✗ gitswitch guard: blocked commit%s\n",
-		red, bold, reset)
-	fmt.Fprintln(os.Stderr)
-	fmt.Fprintf(os.Stderr, "  %sin directory:%s   %s\n", dim, reset, cwd)
-	fmt.Fprintf(os.Stderr, "  %sexpected:%s       %s   (bound identity: %s)\n",
-		dim, reset, id.Email, id.Name)
-	fmt.Fprintf(os.Stderr, "  %sgot:%s            %s\n", dim, reset, effective)
-	fmt.Fprintln(os.Stderr)
-	fmt.Fprintf(os.Stderr, "  %sfix:%s            gitswitch use %s %s\n",
-		dim, reset, id.Name, binding.Directory)
-	fmt.Fprintf(os.Stderr, "                  (or: git commit --no-verify to override this once)\n")
+	fmt.Fprintln(os.Stderr, style.Box(body, style.BoxError))
 	fmt.Fprintln(os.Stderr)
 	os.Exit(1)
 	return nil

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -11,6 +11,12 @@ func NewRootCommand(version string) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "gitswitch",
 		Short: "Stop committing as the wrong person.",
+		// Cobra auto-generates a `completion` subcommand that emits
+		// shell completion scripts. Useful, but in `gitswitch --help`
+		// it adds noise next to our five real commands. Hide it from
+		// the listing — power users still find it via
+		// `gitswitch completion --help`.
+		CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true},
 		Long: `gitswitch — manage multiple Git identities (SSH, gh CLI, signing) ` +
 			`per directory.
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/target-ops/gitswitch/internal/style"
 )
 
 // NewRootCommand wires up the cobra command tree.
@@ -18,7 +20,19 @@ work to a company repo.`,
 		Version:       version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		// PersistentPreRun fires before any subcommand. Use it to honour
+		// --no-color before the subcommand renders anything.
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+			noColor, _ := cmd.Flags().GetBool("no-color")
+			if noColor {
+				style.SetEnabled(false)
+				applyColorState()
+			}
+		},
 	}
+
+	root.PersistentFlags().Bool("no-color", false,
+		"disable colour and decoration in output (also honours $NO_COLOR)")
 
 	root.AddCommand(newDoctorCommand())
 	root.AddCommand(newInitCommand())

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -1,0 +1,210 @@
+// Package style is the gitswitch CLI's single source of truth for
+// colours, icons, and text decoration. Every command in cmd/ should
+// render output through these helpers — no raw "\033[...]" escapes,
+// no fmt.Sprintf-with-color-codes inline.
+//
+// Why centralised:
+//   - One place to flip on --no-color / honour NO_COLOR.
+//   - One place to keep contrast accessible (we don't pick colours
+//     that fail on a light terminal).
+//   - One place to evolve when we add more visual elements (bordered
+//     panels, tables, progress markers).
+package style
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-isatty"
+)
+
+// Disable strips all colour and decoration from style output —
+// equivalent to running with --no-color or NO_COLOR set.
+//
+// Honours the de facto NO_COLOR convention (https://no-color.org)
+// and auto-detects when stdout is not a tty (piped to less, grep,
+// redirected to a file).
+//
+// SetEnabled() / IsEnabled() let the cobra root command flip this
+// based on a --no-color flag at runtime.
+var enabled = autoDetect()
+
+func autoDetect() bool {
+	// Belt + braces: NO_COLOR wins regardless of FORCE_COLOR (privacy
+	// trumps marketing).
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	// FORCE_COLOR is the de facto override for "I know stdout isn't a
+	// tty but I still want colour" (recorders, CI logs, asciinema).
+	if os.Getenv("FORCE_COLOR") != "" {
+		return true
+	}
+	if !isatty.IsTerminal(os.Stdout.Fd()) {
+		return false
+	}
+	return true
+}
+
+// SetEnabled forces colour on or off, overriding the auto-detected
+// default. Call from cmd/root.go after parsing --no-color.
+func SetEnabled(b bool) { enabled = b }
+
+// IsEnabled reports whether style helpers will emit colour.
+func IsEnabled() bool { return enabled }
+
+// ----- semantic styles -----------------------------------------------------
+//
+// Use these helpers in command output. Resist reaching for raw
+// lipgloss in cmd/ files — every visual choice should land here so
+// the look stays coherent.
+
+var (
+	// Foundational colours. We use ANSI 16 for portability — every
+	// terminal renders these the same, no truecolor surprises.
+	colourSuccess = lipgloss.Color("2")  // green
+	colourError   = lipgloss.Color("1")  // red
+	colourWarn    = lipgloss.Color("3")  // yellow
+	colourAccent  = lipgloss.Color("4")  // blue
+	colourMuted   = lipgloss.Color("8")  // bright black (gray)
+
+	successStyle = lipgloss.NewStyle().Foreground(colourSuccess).Bold(true)
+	errorStyle   = lipgloss.NewStyle().Foreground(colourError).Bold(true)
+	warnStyle    = lipgloss.NewStyle().Foreground(colourWarn).Bold(true)
+	accentStyle  = lipgloss.NewStyle().Foreground(colourAccent)
+	mutedStyle   = lipgloss.NewStyle().Foreground(colourMuted)
+	boldStyle    = lipgloss.NewStyle().Bold(true)
+	dimStyle     = lipgloss.NewStyle().Faint(true)
+)
+
+// Render functions — call these from cmd/.
+
+func Success(s string) string { return render(successStyle, s) }
+func Error(s string) string   { return render(errorStyle, s) }
+func Warn(s string) string    { return render(warnStyle, s) }
+func Accent(s string) string  { return render(accentStyle, s) }
+func Muted(s string) string   { return render(mutedStyle, s) }
+func Dim(s string) string     { return render(dimStyle, s) }
+func Bold(s string) string    { return render(boldStyle, s) }
+
+// Path renders an OS path with subtle styling. Different from Muted
+// so we can later distinguish "file path" from "secondary text" if
+// we ever want to.
+func Path(s string) string { return render(mutedStyle, s) }
+
+// Code renders an inline command/code fragment (e.g., `gitswitch use`)
+// with light accent so it stands out without shouting.
+func Code(s string) string { return render(accentStyle, s) }
+
+// ----- icons ---------------------------------------------------------------
+
+const (
+	IconOK    = "✓"
+	IconBad   = "✗"
+	IconWarn  = "•"
+	IconArrow = "→"
+)
+
+// CheckMark, Cross, Bullet — semantic wrappers so cmd/ stays readable.
+func CheckMark() string { return Success(IconOK) }
+func Cross() string     { return Error(IconBad) }
+func Bullet() string    { return Warn(IconWarn) }
+
+// ----- multi-line helpers --------------------------------------------------
+
+// Heading renders a bold header, intended for the first line of a
+// command's output ("✓ active identity: work", "✗ identity drift").
+func Heading(icon, text string) string {
+	if !enabled {
+		return icon + " " + text
+	}
+	return icon + " " + boldStyle.Render(text)
+}
+
+// KV renders a "  label  value" row with the label in muted style
+// and the value plain. The label width is padded so a series of KV
+// rows align; pass labelWidth = 0 for "use the longest label you've
+// rendered so far" (state-free, so callers must compute themselves).
+func KV(label, value string, labelWidth int) string {
+	pad := labelWidth - len(label)
+	if pad < 0 {
+		pad = 0
+	}
+	return fmt.Sprintf("  %s%s   %s",
+		Muted(label+":"),
+		spaces(pad),
+		value,
+	)
+}
+
+// Hint is a dim "→ next step" line, used to suggest the obvious
+// next command after a successful operation.
+func Hint(text string) string {
+	return Muted("  " + IconArrow + " " + text)
+}
+
+// Divider renders a thin horizontal rule of the given width.
+func Divider(width int) string {
+	if width <= 0 {
+		width = 50
+	}
+	r := make([]byte, width)
+	for i := range r {
+		r[i] = '-'
+	}
+	return Muted(string(r))
+}
+
+// ----- panels --------------------------------------------------------------
+
+// BoxStyle picks which palette to wrap a panel in.
+type BoxStyle int
+
+const (
+	BoxNeutral BoxStyle = iota
+	BoxSuccess
+	BoxError
+	BoxWarn
+)
+
+// Box renders `content` inside a thin rounded border. In no-color mode
+// it returns the content as-is — borders without colour just look
+// like noise on plain output.
+func Box(content string, kind BoxStyle) string {
+	if !enabled {
+		return content
+	}
+	colour := colourMuted
+	switch kind {
+	case BoxSuccess:
+		colour = colourSuccess
+	case BoxError:
+		colour = colourError
+	case BoxWarn:
+		colour = colourWarn
+	}
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colour).
+		Padding(0, 1).
+		Render(content)
+}
+
+func render(st lipgloss.Style, s string) string {
+	if !enabled {
+		return s
+	}
+	return st.Render(s)
+}
+
+func spaces(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	r := make([]byte, n)
+	for i := range r {
+		r[i] = ' '
+	}
+	return string(r)
+}


### PR DESCRIPTION
Polish pass on the CLI's visual presentation. *"Make it feel cool in the terminal"* — the disaster-prevention moment is the brand, it should look the part.

## What it looks like now

### \`gitswitch guard install\` — celebratory green panel

\`\`\`
╭─────────────────────────────────────────────────────────────────────────╮
│ ✓ guard installed                                                       │
│                                                                         │
│   hook:           ~/.config/gitswitch/hooks/pre-commit                  │
│   core.hooksPath: ~/.config/gitswitch/hooks                             │
╰─────────────────────────────────────────────────────────────────────────╯

Every \`git commit\` now checks identity vs directory binding.
Override once: git commit --no-verify
Remove later:  gitswitch guard uninstall
\`\`\`

### Wrong-author commit fires the boxed block — red, impossible to miss

\`\`\`
╭──────────────────────────────────────────────────────────────────────╮
│ ✗ gitswitch guard: blocked commit                                    │
│                                                                      │
│   in directory:   ~/work/some-repo                                   │
│   expected:       you@company.com   (bound identity: work)           │
│   got:            you@gmail.com                                      │
│                                                                      │
│   fix:            gitswitch use work ~/work                          │
│                   (or: git commit --no-verify to override this once) │
╰──────────────────────────────────────────────────────────────────────╯
\`\`\`

The block is the project's marquee moment. With a red rounded border around it, every blocked commit becomes a visually striking story — exactly the kind of thing a developer might tweet a screenshot of.

## What's in the PR

| Path | Purpose | Lines |
|---|---|---|
| \`internal/style/style.go\` | Single source of truth for colour + decoration. Built on \`charmbracelet/lipgloss\` (already in dep tree via \`huh\`). Exposes \`Success\`/\`Error\`/\`Warn\`/\`Dim\`/\`Bold\`/\`Code\`/\`Muted\`/\`Path\` renderers, semantic icons, and \`Box(content, kind)\` for bordered panels. | ~170 |
| \`internal/cmd/colors.go\` | The old \`green\`/\`red\`/\`reset\` ANSI consts moved here as package-level vars that zero out when style is disabled. Avoids rewriting 80+ call sites for a policy change. | ~55 |
| \`internal/cmd/root.go\` | New persistent \`--no-color\` flag, \`PersistentPreRun\` re-applies colour state after parsing. | small |
| \`internal/cmd/guard.go\` | \`guard install\` success and \`guard check\` block message wrapped in \`style.Box\` (green / red respectively). | small |

## Colour policy — the right defaults, free escape hatches

| Signal | Behaviour |
|---|---|
| Stdout is a TTY | colour ✓ |
| Stdout is piped (\`\| less\`, \`> file.log\`) | colour ✗ (auto) |
| \`NO_COLOR=1\` env var (no-color.org standard) | colour ✗ |
| \`FORCE_COLOR=1\` env var | colour ✓ (override for asciinema, vhs, CI logs) |
| \`gitswitch --no-color ...\` flag | colour ✗ (overrides everything) |

In \`--no-color\` / pipe modes, \`Box()\` returns content verbatim — no border characters, no escape codes. Plain output stays plain.

## What's NOT in this PR

- **Spinner during \`gitswitch init\` discovery** — discovery is near-instant on a real machine, the spinner is theatre. Deferred until/unless we add slow detectors.
- **ASCII header on \`gitswitch --help\`** — nice-to-have, can be added in a follow-up if the visual feels under-decorated.
- **Migration of every command's output to \`style.X()\`** — would balloon the diff. The \`green\`/\`red\`/\`reset\` prefix-pattern works fine; this PR routes it through policy without rewriting the call sites.

## Verified

- TTY mode (\`FORCE_COLOR=1\`): rounded panels render with colour borders ✓
- \`--no-color\` flag: plain text, no border characters, no escape codes ✓
- \`NO_COLOR=1\` env: same as \`--no-color\` ✓
- Piped stdout: auto-detects, plain text ✓
- \`go vet\`: clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)