### PR TITLE
docs: drop `Why this exists` + `Upgrading from v0.2.x` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,34 +112,11 @@ Once `guard` is installed, every `git commit` runs a ~5 ms check: does `user.ema
 
 ---
 
-## Why this exists
-
-There's a great, obscure git feature called `includeIf` that fixes the directory problem. Nobody documents it well; every blog post about it has a comment from someone who got bitten by the trailing-slash gotcha. Even when it's set up correctly, it doesn't help with SSH (which leaks every key in your agent to every server), and it doesn't help with the GitHub CLI (which has its own opinion about who you are). None of those layers will tell you when they silently disagree.
-
-`gitswitch` sets up `includeIf` correctly the first time, adds per-account SSH host aliases with `IdentitiesOnly yes`, keeps `gh auth` in lockstep, defaults to SSH commit signing so verified-badges come free, and **refuses to let you commit when any of the above is wrong for the directory you're in.**
-
-That last one is the thing.
-
----
-
 ## Philosophy
 
 Git identity should be **infrastructure**, not something you remember.
 
 The tool is small, the binary is single, the only state on your machine lives in `~/.config/gitswitch/` and the directories *you* tell it to manage. No service. No cloud sync of your keys. No telemetry. The maintainer is one developer who got bitten and built this; the issue tracker responds in days, not weeks; the roadmap is public; the tests pass.
-
----
-
-## Upgrading from v0.2.x
-
-The 0.2 line was a Python implementation; v1.0 is a single Go binary with a cleaner config layout.
-
-```bash
-brew upgrade gitswitch
-gitswitch init        # re-detect identities into the new JSON config
-```
-
-The legacy `~/.config.ini` from 0.2.x is left in place — delete it by hand once the new config works.
 
 ---
 


### PR DESCRIPTION
Two trims for tightness, per the maintainer's call.

## What's removed

### \`Why this exists\` (5 paragraphs)

Was a longer restatement of the **The problem** section at the top of the README — same beats (\`includeIf\` is undocumented, SSH leaks keys, \`gh\` has its own opinion, none of these layers talk to each other), spread across more lines. The reader who wanted the explanation already got it before scrolling. Keeping the punchier top-of-page version.

### \`Upgrading from v0.2.x\` (3 paragraphs)

Implied a meaningful v0.2 user base for upgrade docs to exist for. We already concluded that's not the case — see closed [PR #14](https://github.com/target-ops/gitswitch/pull/14) where we dropped the migration command for the same reason. Removing the README section keeps the new-user flow uncluttered.

## Net change

23 lines removed, structure otherwise unchanged. README sections post-trim:

\`\`\`
The problem  →  Install  →  Quickstart  →  What it does
            →  How it compares  →  How it works
            →  Philosophy  →  Community  →  License
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)