### PR TITLE
chore: pin next release to v1.0.1

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,6 +6,7 @@
   "packages": {
     ".": {
       "package-name": "gitswitch",
+      "release-as": "1.0.1",
       "changelog-sections": [
         { "type": "feat",     "section": "Features"        },
         { "type": "fix",      "section": "Bug Fixes"       },


### PR DESCRIPTION
Override release-please's auto-computed version for the immediate next release. `release-as: "1.0.1"` instead of the Conventional-Commits-derived `1.1.0`.

Maintainer's call: this batch is polish + escape hatch (the `--no-color` flag, bordered guard panels, README cleanup), not new headline capability. Patch-level release fits better than minor.

After v1.0.1 ships, remove the override so the next release goes back to auto-computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)