### PR TITLE
fix: use truecolor palette so output reads punchy, not muted grey

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,7 +6,6 @@
   "packages": {
     ".": {
       "package-name": "gitswitch",
-      "release-as": "1.0.1",
       "changelog-sections": [
         { "type": "feat",     "section": "Features"        },
         { "type": "fix",      "section": "Bug Fixes"       },

--- a/internal/cmd/colors.go
+++ b/internal/cmd/colors.go
@@ -36,12 +36,24 @@ func disableColors() {
 	green, yellow, red, blue, dim, bold, reset = "", "", "", "", "", "", ""
 }
 
-// enableColors sets the standard ANSI prefixes/suffix.
+// enableColors sets truecolor (24-bit) ANSI escapes for our palette.
+// Hex → r;g;b mappings match internal/style:
+//
+//	#22c55e (emerald-500) → 34;197;94
+//	#ef4444 (red-500)     → 239;68;68
+//	#f59e0b (amber-500)   → 245;158;11
+//	#3b82f6 (blue-500)    → 59;130;246
+//
+// Terminals that don't support truecolor downsample to 256 / 16
+// colour automatically — the punchy palette degrades gracefully.
+// Was previously bare ANSI-16 (\033[32m etc.) which on modern dark
+// themes reads as muted dim grey rather than the punchy semantic
+// signal we want.
 func enableColors() {
-	green = "\033[32m"
-	yellow = "\033[33m"
-	red = "\033[31m"
-	blue = "\033[34m"
+	green = "\033[38;2;34;197;94m"
+	yellow = "\033[38;2;245;158;11m"
+	red = "\033[38;2;239;68;68m"
+	blue = "\033[38;2;59;130;246m"
 	dim = "\033[2m"
 	bold = "\033[1m"
 	reset = "\033[0m"

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -61,13 +61,22 @@ func IsEnabled() bool { return enabled }
 // the look stays coherent.
 
 var (
-	// Foundational colours. We use ANSI 16 for portability — every
-	// terminal renders these the same, no truecolor surprises.
-	colourSuccess = lipgloss.Color("2")  // green
-	colourError   = lipgloss.Color("1")  // red
-	colourWarn    = lipgloss.Color("3")  // yellow
-	colourAccent  = lipgloss.Color("4")  // blue
-	colourMuted   = lipgloss.Color("8")  // bright black (gray)
+	// Foundational colours. Truecolor hex values, picked from a
+	// saturated palette that pops on both dark and light terminals
+	// without needing AdaptiveColor's background-detection (which
+	// guesses wrong on terminals that don't expose the right escape
+	// sequence). Lipgloss downsamples truecolor automatically when
+	// the terminal supports only 256 / 16 colours, so this also
+	// degrades gracefully on older or restricted environments.
+	//
+	// Previous palette was the bare ANSI-16 (`"2"`, `"1"`, etc.),
+	// which on modern dark themes reads as muted dim grey rather
+	// than the punchy semantic signal we want.
+	colourSuccess = lipgloss.Color("#22c55e") // emerald-500
+	colourError   = lipgloss.Color("#ef4444") // red-500
+	colourWarn    = lipgloss.Color("#f59e0b") // amber-500
+	colourAccent  = lipgloss.Color("#3b82f6") // blue-500
+	colourMuted   = lipgloss.Color("#9ca3af") // gray-400 — readable but recessive
 
 	successStyle = lipgloss.NewStyle().Foreground(colourSuccess).Bold(true)
 	errorStyle   = lipgloss.NewStyle().Foreground(colourError).Bold(true)


### PR DESCRIPTION
Addresses the "I updated to v1.0.1 but I don't see the color" feedback.

## What changed

Two files, same idea: the bare ANSI-16 codes (`\033[32m` etc.) on modern dark themes render as muted dim grey, not the punchy semantic signal a CLI wants. Switched both code paths (`internal/style` lipgloss styles + `internal/cmd/colors.go` prefix strings) to truecolor:

| Semantic | Hex | Before |
|---|---|---|
| ✓ success | `#22c55e` (emerald-500) | ANSI 2 |
| ✗ error | `#ef4444` (red-500) | ANSI 1 |
| • warning | `#f59e0b` (amber-500) | ANSI 3 |
| accent | `#3b82f6` (blue-500) | ANSI 4 |
| muted | `#9ca3af` (gray-400) | ANSI 8 |

Terminals that don't support truecolor downsample to 256/16 automatically — graceful degradation, no breakage.

## Also: drops the stale `release-as: "1.0.1"` override

The override was consumed by v1.0.1's release. With it gone, release-please auto-computes the next version from Conventional Commits since the last tag. This commit is `fix:`, so the bump will be patch-level → **v1.0.2**.

This PR is the **end-to-end test** of the consolidated release workflow (PR #25, just merged):

1. Merge this PR → release-please opens `chore(main): release 1.0.2` PR
2. Merge that PR → goreleaser job (in the same workflow) builds 5 binaries + auto-pushes formula to `target-ops/homebrew-tap`
3. `brew upgrade gitswitch` ships v1.0.2 with truecolor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)