### PR TITLE
fix(doctor): report effective per-directory identity, not just global

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -28,9 +28,18 @@ my last commit go out as the right person?"`,
 }
 
 func runDoctor(_ *cobra.Command, _ []string) error {
-	// 1. git config
-	gitName, gitEmail, _ := git.GlobalIdentity()
-	row("git", strings.TrimSpace(fmt.Sprintf("%s <%s>", gitName, gitEmail)), gitName != "" && gitEmail != "")
+	// 1. git config — report the identity git will ACTUALLY commit as in
+	// this directory (respects local repo config and the includeIf blocks
+	// gitswitch writes), not just the global config. Surface the global
+	// value separately when a directory binding overrides it, so the
+	// switch is visible rather than silently hidden.
+	gitName, gitEmail, _ := git.EffectiveIdentity()
+	row("git (here)", renderIdentity(gitName, gitEmail), gitName != "" && gitEmail != "")
+
+	globalName, globalEmail, _ := git.GlobalIdentity()
+	if globalName != gitName || globalEmail != gitEmail {
+		row("git (global)", renderIdentity(globalName, globalEmail), globalName != "" && globalEmail != "")
+	}
 
 	// 2. ssh ~/.ssh/config Host blocks
 	blocks, err := ssh.ParseConfig()

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -54,6 +54,18 @@ func EffectiveEmail() (string, error) {
 	return configGet("user.email")
 }
 
+// EffectiveIdentity returns the user.name and user.email git would
+// actually use for the next commit in the current working directory.
+// Like EffectiveEmail, this respects local repo config and includeIf
+// chains (which is how gitswitch binds a directory to an identity);
+// outside a repo it falls back to the global values. Either string may
+// be empty if the corresponding config is unset.
+func EffectiveIdentity() (name, email string, err error) {
+	name, _ = configGet("user.name")
+	email, _ = configGet("user.email")
+	return name, email, nil
+}
+
 // SetGlobal writes a value into the user's global git config.
 func SetGlobal(key, value string) error {
 	return exec.Command("git", "config", "--global", key, value).Run()

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,58 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestEffectiveIdentityRespectsLocalOverGlobal is the regression test for
+// the `doctor` bug: a directory binding (modeled here as a local repo
+// override, which is what gitswitch's includeIf block effectively produces)
+// must win over the global config. GlobalIdentity must still report the
+// global values so doctor can show both.
+func TestEffectiveIdentityRespectsLocalOverGlobal(t *testing.T) {
+	// Isolated config so we never touch the developer's real ~/.gitconfig.
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "global.gitconfig"))
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Global identity.
+	run("", "config", "--global", "user.name", "Global Name")
+	run("", "config", "--global", "user.email", "global@example.com")
+
+	// A repo with a local override.
+	repo := t.TempDir()
+	run(repo, "init", "-q")
+	run(repo, "config", "user.name", "Local Name")
+	run(repo, "config", "user.email", "local@example.com")
+
+	// Run our functions from inside the repo.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	name, email, _ := EffectiveIdentity()
+	if name != "Local Name" || email != "local@example.com" {
+		t.Errorf("EffectiveIdentity() = %q <%s>, want \"Local Name\" <local@example.com>", name, email)
+	}
+
+	gName, gEmail, _ := GlobalIdentity()
+	if gName != "Global Name" || gEmail != "global@example.com" {
+		t.Errorf("GlobalIdentity() = %q <%s>, want \"Global Name\" <global@example.com>", gName, gEmail)
+	}
+}


### PR DESCRIPTION
doctor read the git identity via git.GlobalIdentity() (git config --global), so it always printed the global user.name/email and ignored the includeIf blocks gitswitch itself writes to bind a directory to an identity. In a bound directory it reported the wrong identity even though commits went out correctly — a display bug, not a behavior bug.

Switch the git row to git.EffectiveIdentity() (git config without --global, which respects local repo config and includeIf chains), and additionally show the global identity when it differs so the switch is visible. Add EffectiveIdentity() mirroring GlobalIdentity, plus a regression test that a local override wins over global.