### PR TITLE
feat(doctor,why,use): detect local .git/config shadowing a binding

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/target-ops/gitswitch/internal/gh"
 	"github.com/target-ops/gitswitch/internal/git"
+	"github.com/target-ops/gitswitch/internal/identity"
 	"github.com/target-ops/gitswitch/internal/ssh"
 )
 
@@ -84,24 +86,52 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	// 5. cross-check: do gh and ssh agree on who you are?
+	// 5. Is a gitswitch binding being silently shadowed by this repo's
+	// local .git/config? Local config wins over the includeIf (git
+	// precedence: local > global), so the binding can be defeated without
+	// any sign. Detect it so the summary below can't lie with "all agree".
+	var shadowOverrides []string
+	var shadowIdentity string
+	if cwd, err := os.Getwd(); err == nil {
+		if cfg, err := identity.Load(); err == nil {
+			if b := cfg.FindBindingForDir(cwd); b != nil {
+				if ov := git.LocalOverrides(""); len(ov) > 0 {
+					shadowOverrides = ov
+					shadowIdentity = b.Identity
+				}
+			}
+		}
+	}
+
+	// 6. cross-check + summary: shadowing first (the root cause), then
+	// gh-vs-ssh, then the all-clear.
 	ghLogin, _ := gh.ActiveLogin()
-	if ghLogin != "" && len(sshLogins) > 0 {
-		mismatch := false
+	mismatch := false
+	if ghLogin != "" {
 		for _, s := range sshLogins {
 			if s != "" && s != ghLogin {
 				mismatch = true
 			}
 		}
-		if mismatch {
-			fmt.Println()
-			fmt.Println(red + bold + "✗ identity mismatch" + reset)
-			fmt.Printf("  gh says you are:  %s\n", ghLogin)
-			fmt.Printf("  ssh says you are: %s\n", strings.Join(sshLogins, ", "))
-		} else {
-			fmt.Println()
-			fmt.Println(green + bold + "✓ all layers agree" + reset)
-		}
+	}
+	hasCrossCheck := ghLogin != "" && len(sshLogins) > 0
+
+	switch {
+	case len(shadowOverrides) > 0:
+		fmt.Println()
+		fmt.Println(yellow + bold + "⚠ binding shadowed by local .git/config" + reset)
+		fmt.Printf("  %q is bound to this directory, but these keys in this repo's\n", shadowIdentity)
+		fmt.Printf("  .git/config override it: %s%s%s\n", bold, strings.Join(shadowOverrides, ", "), reset)
+		fmt.Printf("  gitswitch isn't in control here. Take over with: %sgitswitch use %s .%s\n",
+			dim, shadowIdentity, reset)
+	case mismatch:
+		fmt.Println()
+		fmt.Println(red + bold + "✗ identity mismatch" + reset)
+		fmt.Printf("  gh says you are:  %s\n", ghLogin)
+		fmt.Printf("  ssh says you are: %s\n", strings.Join(sshLogins, ", "))
+	case hasCrossCheck:
+		fmt.Println()
+		fmt.Println(green + bold + "✓ all layers agree" + reset)
 	}
 	return nil
 }

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -7,9 +7,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 
 	"github.com/target-ops/gitswitch/internal/blocks"
+	"github.com/target-ops/gitswitch/internal/git"
 	"github.com/target-ops/gitswitch/internal/identity"
 )
 
@@ -113,12 +115,74 @@ func runUse(args []string, unbind bool) error {
 	fmt.Println()
 	fmt.Printf("  %sper-identity config:%s %s\n", dim, reset, identity.GitconfigPath(name))
 	fmt.Printf("  %sincludeIf in:%s        %s\n", dim, reset, gitconfigPath)
+
+	// 4. If the bound directory is itself a repo with identity keys set
+	// in its local .git/config, those win over the includeIf we just
+	// wrote (git precedence: local > global) and silently defeat the
+	// binding. Offer to clear them so the binding actually takes effect.
+	authoritative, err := clearShadowingOverrides(dir)
+	if err != nil {
+		return err
+	}
+
 	fmt.Println()
-	fmt.Printf("%scd into %s and your git identity becomes %s automatically.%s\n",
-		dim, dir, name, reset)
+	if authoritative {
+		fmt.Printf("%scd into %s and your git identity becomes %s automatically.%s\n",
+			dim, dir, name, reset)
+	} else {
+		fmt.Printf("%sclear the local overrides above, then cd into %s switches to %s automatically.%s\n",
+			dim, dir, name, reset)
+	}
 	fmt.Println()
 	fmt.Printf("Verify it worked:  %scd %s && gitswitch doctor%s\n", dim, dir, reset)
 	return nil
+}
+
+// clearShadowingOverrides checks dir's local .git/config for identity
+// keys that would shadow the binding we just wrote, and — with the
+// user's confirmation — removes them. Returns whether the binding is now
+// authoritative: true when there were no overrides or they were removed,
+// false when conflicting local config remains.
+func clearShadowingOverrides(dir string) (bool, error) {
+	overrides := git.LocalOverrides(dir)
+	if len(overrides) == 0 {
+		return true, nil
+	}
+
+	fmt.Println()
+	fmt.Printf("  %s⚠ local .git/config overrides this binding:%s\n", yellow, reset)
+	fmt.Printf("      %s%s%s\n", bold, strings.Join(overrides, ", "), reset)
+	fmt.Printf("  %sthese win over the includeIf (git precedence: local > global),%s\n", dim, reset)
+	fmt.Printf("  %sso the binding won't take effect until they're removed.%s\n", dim, reset)
+	fmt.Println()
+
+	var remove bool
+	if err := huh.NewConfirm().
+		Title("Remove these local overrides so the binding takes effect?").
+		Affirmative("Yes, remove").
+		Negative("No, keep them").
+		Value(&remove).
+		Run(); err != nil {
+		// User aborted, or there's no TTY to prompt on (scripts/CI). The
+		// binding is already written — don't fail the command; leave the
+		// overrides and fall through to the manual instructions below.
+		remove = false
+	}
+
+	if !remove {
+		fmt.Printf("  %s• kept local overrides — they still shadow this binding. Clear them with:%s\n", dim, reset)
+		for _, k := range overrides {
+			fmt.Printf("      %sgit -C %s config --local --unset %s%s\n", dim, dir, k, reset)
+		}
+		return false, nil
+	}
+	for _, k := range overrides {
+		if err := git.UnsetLocal(dir, k); err != nil {
+			return false, fmt.Errorf("unset local %s: %w", k, err)
+		}
+	}
+	fmt.Printf("  %s✓ removed local overrides — binding is now authoritative%s\n", green, reset)
+	return true, nil
 }
 
 // buildIncludeIfBlock renders the body of the sentinel-wrapped block

--- a/internal/cmd/why.go
+++ b/internal/cmd/why.go
@@ -79,22 +79,35 @@ func runWhy() error {
 
 	// Case 2 & 3 — render the resolved chain.
 	matches := strings.EqualFold(effective, id.Email)
-	if matches {
-		fmt.Println(green + bold + "✓ active identity: " + id.Name + reset)
-	} else {
+	// A repo's local .git/config wins over the includeIf (git precedence:
+	// local > global). When identity keys are set locally, the binding is
+	// being shadowed — even if the effective email happens to match, it's
+	// a coincidence, not the binding doing its job.
+	overrides := git.LocalOverrides("")
+	shadowed := len(overrides) > 0
+	switch {
+	case !matches:
 		fmt.Println(red + bold + "✗ identity drift" + reset)
+	case shadowed:
+		fmt.Println(yellow + bold + "⚠ binding shadowed by local .git/config" + reset)
+	default:
+		fmt.Println(green + bold + "✓ active identity: " + id.Name + reset)
 	}
 	fmt.Println()
 	fmt.Printf("  %scwd:%s               %s\n", dim, reset, cwd)
 	fmt.Printf("  %sbound directory:%s   %s\n", dim, reset, binding.Directory)
 
-	if matches {
-		fmt.Printf("  %suser.email:%s        %s   %s\n",
-			dim, reset, effective, green+"(matches binding ✓)"+reset)
-	} else {
+	switch {
+	case !matches:
 		fmt.Printf("  %suser.email:%s        %s   %s\n",
 			dim, reset, effective, red+"← MISMATCH"+reset)
 		fmt.Printf("  %sexpected:%s          %s\n", dim, reset, id.Email)
+	case shadowed:
+		fmt.Printf("  %suser.email:%s        %s   %s\n",
+			dim, reset, effective, yellow+"(from local .git/config, not the binding)"+reset)
+	default:
+		fmt.Printf("  %suser.email:%s        %s   %s\n",
+			dim, reset, effective, green+"(matches binding ✓)"+reset)
 	}
 
 	if id.GitName != "" {
@@ -116,6 +129,17 @@ func runWhy() error {
 			strings.TrimRight(binding.Directory, "/")))
 	fmt.Printf("  %sper-identity file:%s %s\n", dim, reset,
 		shortPath(identity.GitconfigPath(id.Name)))
+
+	if shadowed {
+		fmt.Println()
+		fmt.Println(yellow + bold + "⚠ this repo's local .git/config overrides the binding" + reset)
+		fmt.Printf("  %sset locally, so they win over the includeIf above:%s\n", dim, reset)
+		fmt.Printf("      %s%s%s\n", bold, strings.Join(overrides, ", "), reset)
+		fmt.Println()
+		fmt.Printf("  %sgitswitch isn't really in control here. Take over with:%s\n", dim, reset)
+		fmt.Printf("  %sgitswitch use %s %s%s\n", dim, id.Name, binding.Directory, reset)
+		fmt.Printf("  %s(it will offer to remove the local overrides)%s\n", dim, reset)
+	}
 
 	if !matches {
 		fmt.Println()

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -66,6 +66,64 @@ func EffectiveIdentity() (name, email string, err error) {
 	return name, email, nil
 }
 
+// IdentityKeys are the git config keys gitswitch manages through its
+// per-identity gitconfig (included via includeIf). When any of these is
+// also set in a repo's LOCAL .git/config, the local value wins — git's
+// precedence is local > global/includeIf — and silently defeats a
+// gitswitch binding. These are the keys worth checking for shadowing.
+var IdentityKeys = []string{"user.name", "user.email", "user.signingkey", "core.sshCommand"}
+
+// LocalOverrides returns the subset of IdentityKeys that are set in the
+// LOCAL .git/config of the repo at dir. Pass "" for the current working
+// directory. The result is empty when dir isn't a git repo or nothing
+// identity-related is set locally — so a non-empty result means a
+// gitswitch binding for that location is being shadowed.
+func LocalOverrides(dir string) []string {
+	var set []string
+	for _, k := range IdentityKeys {
+		if localGet(dir, k) != "" {
+			set = append(set, k)
+		}
+	}
+	return set
+}
+
+// localGet reads a single key from dir's local .git/config only (never
+// global/includeIf). Empty string when unset or dir isn't a repo.
+func localGet(dir, key string) string {
+	args := []string{}
+	if dir != "" {
+		args = append(args, "-C", dir)
+	}
+	args = append(args, "config", "--local", "--get", key)
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "" // unset, or not inside a repo — both are "no override"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// UnsetLocal removes key from dir's local .git/config. Pass "" for the
+// current working directory. Treated as success when the key wasn't set
+// in the first place — that's what the caller wants.
+func UnsetLocal(dir, key string) error {
+	args := []string{}
+	if dir != "" {
+		args = append(args, "-C", dir)
+	}
+	args = append(args, "config", "--local", "--unset", key)
+	err := exec.Command("git", args...).Run()
+	if err == nil {
+		return nil
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) && ee.ExitCode() == 5 {
+		// `git config --unset` exits 5 when the key didn't exist.
+		return nil
+	}
+	return err
+}
+
 // SetGlobal writes a value into the user's global git config.
 func SetGlobal(key, value string) error {
 	return exec.Command("git", "config", "--global", key, value).Run()

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -56,3 +56,65 @@ func TestEffectiveIdentityRespectsLocalOverGlobal(t *testing.T) {
 		t.Errorf("GlobalIdentity() = %q <%s>, want \"Global Name\" <global@example.com>", gName, gEmail)
 	}
 }
+
+// TestLocalOverridesAndUnset covers the shadow-detection primitives: a
+// repo with identity keys in its local .git/config is reported by
+// LocalOverrides, and UnsetLocal clears them so nothing is left to
+// shadow a gitswitch binding.
+func TestLocalOverridesAndUnset(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "global.gitconfig"))
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+
+	repo := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	run("config", "user.email", "local@example.com")
+	run("config", "core.sshCommand", "ssh -i /tmp/key")
+
+	got := LocalOverrides(repo)
+	want := map[string]bool{"user.email": true, "core.sshCommand": true}
+	if len(got) != len(want) {
+		t.Fatalf("LocalOverrides() = %v, want keys %v", got, want)
+	}
+	for _, k := range got {
+		if !want[k] {
+			t.Errorf("LocalOverrides() returned unexpected key %q", k)
+		}
+	}
+
+	// A directory with no local overrides reports none.
+	clean := t.TempDir()
+	runIn(t, clean, "init", "-q")
+	if ov := LocalOverrides(clean); len(ov) != 0 {
+		t.Errorf("LocalOverrides(clean repo) = %v, want empty", ov)
+	}
+
+	// UnsetLocal clears them; a second unset is a no-op (not an error).
+	for _, k := range []string{"user.email", "core.sshCommand"} {
+		if err := UnsetLocal(repo, k); err != nil {
+			t.Fatalf("UnsetLocal(%q): %v", k, err)
+		}
+		if err := UnsetLocal(repo, k); err != nil {
+			t.Errorf("UnsetLocal(%q) second call should be a no-op, got %v", k, err)
+		}
+	}
+	if ov := LocalOverrides(repo); len(ov) != 0 {
+		t.Errorf("after UnsetLocal, LocalOverrides() = %v, want empty", ov)
+	}
+}
+
+func runIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}


### PR DESCRIPTION
## What

A repo's **local `.git/config` wins over the `includeIf`** gitswitch writes (git precedence: `local > global`). So when `user.name` / `user.email` / `user.signingkey` / `core.sshCommand` are set in a repo's `.git/config`, they **silently defeat a gitswitch binding** — commits and pushes go out under the local identity, while `gitswitch why` happily reports the binding is active (the effective email matches only by *coincidence*).

This is the **#1 adoption trap**: anyone who set per-repo identities the old way (`git config user.email …`) before adopting gitswitch hits it, and the tool gives them false confidence instead of a warning.

gitswitch keeps control at the identity layer (still `includeIf`, which is its whole value — one binding covers a tree, including repos cloned later) but now makes the conflict **visible and resolvable**.

## Changes

- **`git`**: `LocalOverrides(dir)` detects identity keys set in a repo's local `.git/config`; `UnsetLocal(dir, key)` clears them.
- **`why`**: replaces the misleading `(matches binding ✓)` with `⚠ binding shadowed by local .git/config`, lists the offending keys, and shows the take-over command.
- **`doctor`**: folds the same detection into the final summary, so it can no longer print `✓ all layers agree` while a binding is silently shadowed.
- **`use`**: after binding, detects shadowing local config and **prompts (y/N)** to remove it so the binding actually takes effect. On decline or no-TTY it keeps the keys and prints the exact manual `git config --local --unset` commands; the closing message no longer promises automatic switching when overrides remain.
- **tests**: cover `LocalOverrides` + `UnsetLocal` (detect, no-op on clean repo, clear, idempotent re-unset).

## Before / after — `why` in a shadowed repo

```
# before  (false confidence)
✓ active identity: private
  user.email:        ofir474@gmail.com   (matches binding ✓)

# after  (the truth)
⚠ binding shadowed by local .git/config
  user.email:        ofir474@gmail.com   (from local .git/config, not the binding)
  ...
⚠ this repo's local .git/config overrides the binding
  set locally, so they win over the includeIf above:
      user.name, user.email, core.sshCommand
  gitswitch isn't really in control here. Take over with:
  gitswitch use private <dir>   (it will offer to remove the local overrides)
```

## Design note (non-goal)

gitswitch does **not** take over auth/credential management (gh account, HTTPS credential helper) — that's machine-wide, gh/keychain-owned state. This PR is detection + opt-in cleanup of *git config* shadowing only, consistent with `why`/`doctor`'s "tell me when my identity layers disagree" mission.

## Test plan

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/...` — git package tests pass (incl. new ones)
- Ran `why` / `doctor` / `use` against a real shadowed repo: shadowing is detected; `use` prompts and (on confirm) clears it; a non-shadowed repo shows no warning (no false positives).
